### PR TITLE
Add ReleaseControl Function. Works with CUESDK.x64_2013.dll

### DIFF
--- a/cue_sdk/cue_api.py
+++ b/cue_sdk/cue_api.py
@@ -35,6 +35,9 @@ class CUE(object):
         self._libcue.CorsairRequestControl.restype = c_bool
         self._libcue.CorsairRequestControl.argtypes = [c_int]
 
+        self._libcue.CorsairReleaseControl.restype = c_bool
+        self._libcue.CorsairReleaseControl.argtypes = [c_int]
+
         self._libcue.CorsairPerformProtocolHandshake.restype = CorsairProtocolDetails
 
         self._libcue.CorsairGetLastError.restype = c_int

--- a/cue_sdk/cue_api.py
+++ b/cue_sdk/cue_api.py
@@ -74,6 +74,9 @@ class CUE(object):
     def RequestControl(self, access_mode):
         return self._libcue.CorsairRequestControl(access_mode)
 
+    def ReleaseControl(self, access_mode):
+        return self._libcue.CorsairReleaseControl(access_mode)
+
     def PerformProtocolHandshake(self):
         return self._libcue.CorsairPerformProtocolHandshake()
 


### PR DESCRIPTION
Add ReleaseControl Function. Works with CUESDK.x64_2013.dll. Useful if you want to release the keyboard back to CUE (or other software using the SDK.)
