### PR TITLE
Support Python 3.6 & 32-bit Python

### DIFF
--- a/cue_sdk/enumerations.py
+++ b/cue_sdk/enumerations.py
@@ -9,9 +9,14 @@ def with_metaclass(meta, *bases):
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
-    class metaclass(meta):
+    class metaclass(type):
+
         def __new__(cls, name, this_bases, d):
             return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
     return type.__new__(metaclass, 'temporary_class', (), {})
 
 

--- a/examples/callback.py
+++ b/examples/callback.py
@@ -17,6 +17,6 @@ def main():
 
 
 if __name__ == "__main__":
-    cue = CUESDK("CUESDK.x64_2013.dll")
+    cue = CUESDK("CUESDK_2015.dll")
     cue.request_control(CAM.ExclusiveLightingControl)
     main()

--- a/examples/callback.py
+++ b/examples/callback.py
@@ -1,5 +1,6 @@
 #!python3
 import time
+import sys
 
 from cue_sdk import *
 
@@ -17,6 +18,13 @@ def main():
 
 
 if __name__ == "__main__":
-    cue = CUESDK("CUESDK_2015.dll")
+    # To determine whether or not we are using a 64-bit version of Python,
+    # we will check sys.maxsize. 64-bit Python will have a maxsize value of
+    # 9223372036854775807, while 32-bit Python will have a mazsize value of
+    # 2147483647.
+    if sys.maxsize == 9223372036854775807:
+        cue = CUESDK("CUESDK.x64_2015.dll")
+    else:
+        cue = CUESDK("CUESDK_2015.dll")
     cue.request_control(CAM.ExclusiveLightingControl)
     main()

--- a/examples/color_pulse.py
+++ b/examples/color_pulse.py
@@ -63,6 +63,6 @@ def main():
 
 
 if __name__ == "__main__":
-    cue = CUESDK("CUESDK.x64_2013.dll")
+    cue = CUESDK("CUESDK_2015.dll")
     cue.request_control(CAM.ExclusiveLightingControl)
     main()

--- a/examples/color_pulse.py
+++ b/examples/color_pulse.py
@@ -3,6 +3,7 @@ from __future__ import division
 import win32api
 import win32con
 import time
+import sys
 
 from cue_sdk import *
 
@@ -63,6 +64,13 @@ def main():
 
 
 if __name__ == "__main__":
-    cue = CUESDK("CUESDK_2015.dll")
+    # To determine whether or not we are using a 64-bit version of Python,
+    # we will check sys.maxsize. 64-bit Python will have a maxsize value of
+    # 9223372036854775807, while 32-bit Python will have a mazsize value of
+    # 2147483647.
+    if sys.maxsize == 9223372036854775807:
+        cue = CUESDK("CUESDK.x64_2015.dll")
+    else:
+        cue = CUESDK("CUESDK_2015.dll")
     cue.request_control(CAM.ExclusiveLightingControl)
     main()

--- a/examples/text_highlight.py
+++ b/examples/text_highlight.py
@@ -1,5 +1,6 @@
 # Python port of text_highlight.cpp from the CUE SDK examples.
 import time
+import sys
 
 import cue_sdk
 from cue_sdk import *
@@ -36,6 +37,13 @@ def main():
             highlight_key(led_id)
 
 if __name__ == "__main__":
-    cue = CUESDK("CUESDK_2015.dll")
+    # To determine whether or not we are using a 64-bit version of Python,
+    # we will check sys.maxsize. 64-bit Python will have a maxsize value of
+    # 9223372036854775807, while 32-bit Python will have a mazsize value of
+    # 2147483647.
+    if sys.maxsize == 9223372036854775807:
+        cue = CUESDK("CUESDK.x64_2015.dll")
+    else:
+        cue = CUESDK("CUESDK_2015.dll")
     cue.request_control(CAM.ExclusiveLightingControl)
     main()

--- a/examples/text_highlight.py
+++ b/examples/text_highlight.py
@@ -36,6 +36,6 @@ def main():
             highlight_key(led_id)
 
 if __name__ == "__main__":
-    cue = CUESDK("CUESDK.x64_2013.dll")
+    cue = CUESDK("CUESDK_2015.dll")
     cue.request_control(CAM.ExclusiveLightingControl)
     main()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 3'
     ],
 
-    keywords='Corsair CUE Strafe Void Scimitar K95 K70 K65 M65 Sabre RGB Keyboard Mouse',
+    keywords='Corsair CUE Strafe Void Scimitar K95 K70 K68 K65 M65 Sabre RGB Keyboard Mouse',
 
     packages=['cue_sdk'],
 


### PR DESCRIPTION
This pull request does a few things:

1.) Update the "with_metaclass" function found in cue_sdk/enumerations.py with the latest version of the function from six.py, which gets cue_sdk working on Python 3.6 while preserving Python 2.7 support.

2.) Update examples to use newer 2015 CUE SDK DLLs.

3.) Use sys.maxsize to determine whether or not the user is using 32-bit Python or 64-bit Python, and use the proper DLL.

4.) Add K68 to setup.py keywords

Tested on Python 2.7.14 (32-bit & 64-bit), Python 3.5.4 (32-bit & 64-bit), and Python 3.6.5 (32-bit & 64-bit) on Windows 10 Pro (1709, 64-bit). Keyboard used for testing is the Corsair K68 RGB.